### PR TITLE
Fix "upsample_after_warp"

### DIFF
--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -465,8 +465,10 @@ class Dataset(gdal.Dataset):
 
     def GetNativeResolution(self, transform=None, maximum=None):
         """
-        Get a native destination resolution that does not reduce the precision
-        of the source data.
+        of the source data; this usually means upsampling the data, but if the
+        pixel dimensions are slightly smaller than a given resolution, and
+        equal within error tolerance, that resolution will get chosen as the
+        native one.
         """
         # Get the source projection's units for a 1x1 pixel, assuming square
         # pixels.

--- a/gdal2mbtiles/helpers.py
+++ b/gdal2mbtiles/helpers.py
@@ -187,7 +187,7 @@ def warp_mbtiles(inputfile, outputfile, metadata, colors=None, band=None,
         warped = preprocess(inputfile=inputfile, outputfile=tempfile.name,
                             band=band, spatial_ref=spatial_ref,
                             resampling=resampling, compress='LZW')
-        preprocessor = partial(upsample_after_warp,
+        preprocessor = partial(resample_after_warp,
                                whole_world=dataset.IsWholeWorld())
         return image_mbtiles(inputfile=warped, outputfile=outputfile,
                              metadata=metadata,
@@ -243,7 +243,7 @@ def warp_pyramid(inputfile, outputdir, colors=None, band=None,
         warped = preprocess(inputfile=inputfile, outputfile=tempfile.name,
                             band=band, spatial_ref=spatial_ref,
                             resampling=resampling, compress='LZW')
-        preprocessor = partial(upsample_after_warp,
+        preprocessor = partial(resample_after_warp,
                                whole_world=dataset.IsWholeWorld())
         return image_pyramid(inputfile=warped, outputdir=outputdir,
                              min_resolution=min_resolution,
@@ -289,7 +289,7 @@ def warp_slice(inputfile, outputdir, fill_borders=None, colors=None, band=None,
         warped = preprocess(inputfile=inputfile, outputfile=tempfile.name,
                             band=band, spatial_ref=spatial_ref,
                             resampling=resampling, compress='LZW')
-        preprocessor = partial(upsample_after_warp,
+        preprocessor = partial(resample_after_warp,
                                whole_world=dataset.IsWholeWorld())
         return image_slice(inputfile=warped, outputdir=outputdir,
                            colors=colors, renderer=renderer,
@@ -299,17 +299,17 @@ def warp_slice(inputfile, outputdir, fill_borders=None, colors=None, band=None,
 
 # Preprocessors
 
-def upsample_after_warp(pyramid, colors, whole_world, **kwargs):
+def resample_after_warp(pyramid, colors, whole_world, **kwargs):
     resolution = pyramid.dataset.GetNativeResolution()
     if whole_world:
-        # We must upsample the image to fit whole tiles, even if this makes the
+        # We must resample the image to fit whole tiles, even if this makes the
         # extents of the image go PAST the full world.
         #
         # This is because GDAL sometimes reprojects from a whole world image
         # into a partial world image, due to rounding errors.
-        pyramid.dataset.upsample_to_world()
+        pyramid.dataset.resample_to_world()
     else:
-        pyramid.dataset.upsample(resolution=resolution)
+        pyramid.dataset.resample(resolution=resolution)
     colorize(pyramid=pyramid, colors=colors)
     pyramid.dataset.align_to_grid(resolution=resolution)
     return pyramid

--- a/gdal2mbtiles/vips.py
+++ b/gdal2mbtiles/vips.py
@@ -692,8 +692,13 @@ class VipsDataset(Dataset):
         )
 
         with LibVips.disable_warnings():
-            self._image = self.image.stretch(xscale=ratios.x,
-                                             yscale=ratios.y)
+            if ratios > XY(x=1.0, y=1.0):
+                self._image = self.image.stretch(xscale=ratios.x,
+                                                 yscale=ratios.y)
+            else:
+                self._image = self.image.shrink(xscale=ratios.x,
+                                                yscale=ratios.y)
+
             # Fix the dataset's metadata
             geotransform = list(self.GetGeoTransform())
             geotransform[1] = width / self._image.Xsize()    # pixel width

--- a/gdal2mbtiles/vips.py
+++ b/gdal2mbtiles/vips.py
@@ -673,7 +673,7 @@ class VipsDataset(Dataset):
             nodata = self.GetRasterBand(1).GetNoDataValue()
             self._image = colors.colorize(image=self.image, nodata=nodata)
 
-    def _upsample(self, ratios):
+    def _resample(self, ratios):
         if ratios == XY(x=1.0, y=1.0):
             # No upsampling needed
             return
@@ -707,20 +707,20 @@ class VipsDataset(Dataset):
             self.SetLocalSizes(xsize=self._image.Xsize(),
                                ysize=self._image.Ysize())
 
-    def upsample(self, resolution=None):
-        """Upsamples the image to `resolution`."""
-        return self._upsample(
+    def resample(self, resolution=None):
+        """Resamples the image to `resolution`."""
+        return self._resample(
             ratios=self.GetScalingRatios(resolution=resolution, places=5)
         )
 
-    def upsample_to_world(self):
-        """Upsamples the image to native TMS resolution for the whole world."""
+    def resample_to_world(self):
+        """Resamples the image to native TMS resolution for the whole world."""
         ratios = self.GetWorldScalingRatios()
         if ratios == XY(x=1.0, y=1.0):
-            # No upsampling needed
+            # No resampling needed
             return
 
-        result = self._upsample(ratios=ratios)
+        result = self._resample(ratios=ratios)
 
         # Force world to be full width by changing pixel width
         world = self.GetSpatialReference().GetWorldExtents()

--- a/tests/test_vips.py
+++ b/tests/test_vips.py
@@ -184,10 +184,10 @@ class TestVipsDataset(GdalTestCase):
 
         self.upsamplingfile = os.path.join(__dir__, 'upsampling.tif')
 
-    def test_upsample(self):
+    def test_resample(self):
         # bluemarble-foreign.tif is a 500 × 250 whole-world map.
         dataset = VipsDataset(inputfile=self.foreignfile)
-        dataset.upsample(resolution=None)
+        dataset.resample(resolution=None)
         self.assertEqual(dataset.RasterXSize, dataset.image.Xsize())
         self.assertEqual(dataset.RasterYSize, dataset.image.Ysize())
         self.assertEqual(dataset.RasterXSize, 512)

--- a/tests/test_vips.py
+++ b/tests/test_vips.py
@@ -177,6 +177,9 @@ class TestVipsDataset(GdalTestCase):
 
         self.foreignfile = os.path.join(__dir__,
                                         'bluemarble-foreign.tif')
+        self.slightlytoobigfile = os.path.join(
+            __dir__, 'bluemarble-slightly-too-big.tif'
+        )
 
         self.spanningforeignfile = os.path.join(
             __dir__, 'bluemarble-spanning-foreign.tif'
@@ -184,7 +187,7 @@ class TestVipsDataset(GdalTestCase):
 
         self.upsamplingfile = os.path.join(__dir__, 'upsampling.tif')
 
-    def test_resample(self):
+    def test_upsample(self):
         # bluemarble-foreign.tif is a 500 × 250 whole-world map.
         dataset = VipsDataset(inputfile=self.foreignfile)
         dataset.resample(resolution=None)
@@ -192,6 +195,20 @@ class TestVipsDataset(GdalTestCase):
         self.assertEqual(dataset.RasterYSize, dataset.image.Ysize())
         self.assertEqual(dataset.RasterXSize, 512)
         self.assertEqual(dataset.RasterYSize, 512)
+
+    def test_downsample(self):
+        """
+        Test that a 258x258 file will get downsampled to
+        256x256 instead of upsampled to the next resolution.
+        Because the pixel size is within error tolerance
+        of the lower resolution's pixel size
+        """
+        dataset = VipsDataset(inputfile=self.slightlytoobigfile)
+        dataset.resample(resolution=None)
+        self.assertEqual(dataset.RasterXSize, dataset.image.Xsize())
+        self.assertEqual(dataset.RasterYSize, dataset.image.Ysize())
+        self.assertEqual(dataset.RasterXSize, 256)
+        self.assertEqual(dataset.RasterYSize, 256)
 
     def test_align_to_grid(self):
         with LibVips.disable_warnings():


### PR DESCRIPTION
Fixes #6 

Allow for either upsampling or downsampling for the initial resampling.

To decide the native resolution, gdal.Dataset.GetNativeResolution iterates upwards through integer resolutions - defining the "native resolution" as the first where the resolution's pixel size is smaller than the original pixel size. So theoretically, this should always lead to upsampling to the next highest resolution.

But, there is an allowance for floating point error, which is based on the size of the major circumference at the given resolution. So when the resolution's pixel size is actually slightly bigger than the original pixel size, but within the error tolerance, that will be chosen as the native resolution. This in turn was leading to scaling ratios of > 1.0, which caused `VImage.stretch` to raise a ValueError when upsampling the image to the chosen native resolution.

This now looks at the scaling ratios and calls either `stretch` or `shrink` based on the values. I've also renamed "upsample" to "resample" in the relevent places.