### PR TITLE
Fix tile alignment issue

### DIFF
--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function,
 
 from functools import partial
 import logging
-from math import pi
+from math import ceil, floor, pi
 from itertools import count
 import os
 import re
@@ -690,10 +690,10 @@ class Dataset(gdal.Dataset):
         right, top = spatial_ref.OffsetPoint(*extents.upper_right)
 
         # Divide by number of tiles
-        return Extents(lower_left=XY(int(round(left / tile_width)),
-                                     int(round(bottom / tile_height))),
-                       upper_right=XY(int(round(right / tile_width)),
-                                      int(round(top / tile_height))))
+        return Extents(lower_left=XY(int(floor(left / tile_width)),
+                                     int(floor(bottom / tile_height))),
+                       upper_right=XY(int(ceil(right / tile_width)),
+                                      int(ceil(top / tile_height))))
 
     def GetWorldScalingRatios(self, resolution=None, places=None):
         """

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -837,6 +837,10 @@ class TestDataset(TestCase):
         self.assertExtentsEqual(dataset.GetTmsExtents(),
                                 Extents(lower_left=XY(1, 1),
                                         upper_right=XY(2, 2)))
+        # At resolution 3, it occupies 2x2 tiles
+        self.assertExtentsEqual(dataset.GetTmsExtents(resolution=3),
+                                Extents(lower_left=XY(2, 2),
+                                        upper_right=XY(4, 4)))
         # At resolution 1, should only occupy lower-left quadrant
         self.assertExtentsEqual(dataset.GetTmsExtents(resolution=1),
                                 Extents(lower_left=XY(0, 0),


### PR DESCRIPTION
If an image only partially covers a tile, there are alignment issues caused by using round() in GetTmsExtents() (introduced in 923113317a6823ffb94dbca53f553f1e125ff6d9).

For example, if an image covers between lower_left=(0.6,0.6) and upper_right=(1.2, 1.2) in tile coordinates, the tile extent returned by TmsExtent would be lower_left=(1, 1), upper_right=(1,1). When really it should return lower_left=(0,0) upper_right=(2,2).

So we should use floor() for rounding the lower_left point and ceil() for rounding the upper_right point.