### PR TITLE
Delete obsolete comment

### DIFF
--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -940,7 +940,6 @@ class VRT(object):
                     # gdal_translate does not support the following
                     # '-multi',               # Use multiple processes
                     # '-overwrite',           # Overwrite outputfile
-                    # '-wo', 'NUM_THREADS=ALL_CPUS',  # Use all CPUs
                 ]
 
                 # Set the working memory so that gdalwarp doesn't stall of disk


### PR DESCRIPTION
As gdal_translate does now accept a NUM_THREADS create option (since GDAL 2.1), and PR #17 added it, we should delete the obsolete and potentially confusing comment stating that it's not supported.