### PR TITLE
Fix tile alignment issue

### DIFF
--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -25,7 +25,7 @@ from builtins import round
 
 from functools import partial
 import logging
-from math import ceil, floor, pi
+from math import pi
 from itertools import count
 import os
 import re
@@ -707,10 +707,10 @@ class Dataset(gdal.Dataset):
         right, top = spatial_ref.OffsetPoint(*extents.upper_right)
 
         # Divide by number of tiles
-        return Extents(lower_left=XY(int(floor(left / tile_width)),
-                                     int(floor(bottom / tile_height))),
-                       upper_right=XY(int(ceil(right / tile_width)),
-                                      int(ceil(top / tile_height))))
+        return Extents(lower_left=XY(int(round(left / tile_width)),
+                                     int(round(bottom / tile_height))),
+                       upper_right=XY(int(round(right / tile_width)),
+                                      int(round(top / tile_height))))
 
     def GetWorldScalingRatios(self, resolution=None, places=None):
         """

--- a/tests/test_gdal.py
+++ b/tests/test_gdal.py
@@ -844,10 +844,6 @@ class TestDataset(TestCase):
         self.assertExtentsEqual(dataset.GetTmsExtents(),
                                 Extents(lower_left=XY(1, 1),
                                         upper_right=XY(2, 2)))
-        # At resolution 3, it occupies 2x2 tiles
-        self.assertExtentsEqual(dataset.GetTmsExtents(resolution=3),
-                                Extents(lower_left=XY(2, 2),
-                                        upper_right=XY(4, 4)))
         # At resolution 1, should only occupy lower-left quadrant
         self.assertExtentsEqual(dataset.GetTmsExtents(resolution=1),
                                 Extents(lower_left=XY(0, 0),


### PR DESCRIPTION
This reverts PR #10 
PR #10 changed round() in get_tile_extents() to use floor() and ceil() instead, reportedly to fix an issue introduced by commit [9231133](https://github.com/ecometrica/gdal2mbtiles/commit/923113317a6823ffb94dbca53f553f1e125ff6d9).  However, we are seeing the same tile alignment issues described in 9231133 again, which appear to have been caused by this change.  