### PR TITLE
fix: Use the major Circumference function if the spatial reference is…

### DIFF
--- a/gdal2mbtiles/constants.py
+++ b/gdal2mbtiles/constants.py
@@ -20,6 +20,9 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from math import pi
+from numpy import array
+
 
 # EPSG constants
 EPSG_WEB_MERCATOR = 3857
@@ -35,3 +38,16 @@ TILE_SIDE = 256                 # in pixels
 GDALINFO = 'gdalinfo'
 GDALTRANSLATE = 'gdal_translate'
 GDALWARP = 'gdalwarp'
+
+# SEMI_MAJOR is a constant referring to the WGS84 Semi Major Axis.
+WGS84_SEMI_MAJOR = 6378137.0
+
+# Note: web-Mercator = pseudo-Mercator = EPSG 3857
+# The extents of the web-Mercator are constants.
+# Since the projection is formed from a sphere the extents of the projection
+# form a square.
+# For the values of the extents refer to:
+# OpenLayer lib: http://docs.openlayers.org/library/spherical_mercator.html
+EPSG3857_EXTENT = pi * WGS84_SEMI_MAJOR
+
+EPSG3857_EXTENTS = array([[-EPSG3857_EXTENT]*2, [EPSG3857_EXTENT]*2])

--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -851,12 +851,12 @@ class SpatialReference(osr.SpatialReference):
         if self.IsProjected() == 0:
             return 2 * pi / self.GetAngularUnits()
 
-        semi_minor = self.GetSemiMinor() * 2 * pi / self.GetLinearUnits()
         if self.GetEPSGCode() == 3857:
-            # Cancel the flattening of the spheroid.
-            # This is to account for the web mercator projection of points on
-            # a spheroid but interpretation of said points on a sphere.
-            return semi_minor / (1 - 1 / self.GetInvFlattening())
+            # Return the Major Circumference since the 3857 is a
+            # projection from a sphere.
+            return self.GetMajorCircumference()
+
+        semi_minor = self.GetSemiMinor() * 2 * pi / self.GetLinearUnits()
         return semi_minor
 
     def GetWorldExtents(self):

--- a/tests/test_spatial_reference.py
+++ b/tests/test_spatial_reference.py
@@ -3,28 +3,14 @@
 
 import rasterio
 import pytest
-from math import pi
 
 from numpy import array
 from numpy.testing import assert_array_almost_equal
 
-from gdal2mbtiles.constants import EPSG_WEB_MERCATOR
-
+from gdal2mbtiles.constants import (EPSG_WEB_MERCATOR,
+                                    EPSG3857_EXTENTS)
 from gdal2mbtiles.gdal import SpatialReference
 
-
-# SEMI_MAJOR is a constant referring to the WGS84 Semi Major Axis.
-SEMI_MAJOR = 6378137.0
-
-# Note: web-Mercator = pseudo-Mercator = EPSG 3857
-# The extents of the web-Mercator are constants.
-# Since the projection is formed from a sphere the extents of the projection
-# form a square.
-# For the values of the extents refer to:
-# OpenLayer lib: http://docs.openlayers.org/library/spherical_mercator.html
-EPSG3857_EXTENT = pi * SEMI_MAJOR
-
-EPSG3857_EXTENTS = array([[-EPSG3857_EXTENT]*2, [EPSG3857_EXTENT]*2])
 
 epsg_3857_raster_path = 'tests/web_mercator_3857.tif'
 

--- a/tests/test_spatial_reference.py
+++ b/tests/test_spatial_reference.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+
+
+import rasterio
+import pytest
+from math import pi
+
+from numpy import array
+from numpy.testing import assert_array_almost_equal
+
+from gdal2mbtiles.constants import EPSG_WEB_MERCATOR
+
+from gdal2mbtiles.gdal import SpatialReference
+
+
+# SEMI_MAJOR is a constant referring to the WGS84 Semi Major Axis.
+SEMI_MAJOR = 6378137.0
+
+# Note: web-Mercator = pseudo-Mercator = EPSG 3857
+# The extents of the web-Mercator are constants.
+# Since the projection is formed from a sphere the extents of the projection
+# form a square.
+# For the values of the extents refer to:
+# OpenLayer lib: http://docs.openlayers.org/library/spherical_mercator.html
+EPSG3857_EXTENT = pi * SEMI_MAJOR
+
+EPSG3857_EXTENTS = array([[-EPSG3857_EXTENT]*2, [EPSG3857_EXTENT]*2])
+
+epsg_3857_raster_path = 'tests/web_mercator_3857.tif'
+
+
+@pytest.fixture
+def epsg_3857_from_proj4():
+    """
+    Return a gdal spatial reference object with
+    3857 crs using the ImportFromProj4 method.
+    """
+    ds_3857 = rasterio.open(epsg_3857_raster_path)
+    spatial_ref = SpatialReference()
+    spatial_ref.ImportFromProj4(ds_3857.crs.to_string())
+    return spatial_ref
+
+
+@pytest.fixture
+def epsg_3857_from_epsg():
+    """
+    Return a gdal spatial reference object with
+    3857 crs using the FromEPSG method.
+    """
+    spatial_ref = SpatialReference.FromEPSG(EPSG_WEB_MERCATOR)
+    return spatial_ref
+
+
+def test_epsg_3857_proj4(epsg_3857_from_proj4):
+    extents = epsg_3857_from_proj4.GetWorldExtents()
+    extents = array(extents)
+    assert_array_almost_equal(extents, EPSG3857_EXTENTS, decimal=3)
+
+
+def test_epsg_3857_from_epsg(epsg_3857_from_epsg):
+    extents = epsg_3857_from_epsg.GetWorldExtents()
+    extents = array(extents)
+    assert_array_almost_equal(extents, EPSG3857_EXTENTS, decimal=3)

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 
-envlist = py27,py35,py36
+envlist = py{27,35,36}
 
 [testenv]
 commands=
-    pip install --global-option=build_ext --global-option=--gdal-config=/usr/bin/gdal-config --global-option=-I/usr/include/gdal GDAL=={env:GDAL_VERSION:2.3.1}
+    pip install --global-option=build_ext --global-option=--gdal-config=/usr/bin/gdal-config --global-option=-I/usr/include/gdal GDAL=={env:GDAL_VERSION:2.1.3}
     pip install rasterio
     pytest {posargs}
 whitelist_externals = env

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist = py27,py35,py36
 
 [testenv]
 commands=
-    pip install --global-option=build_ext --global-option=--gdal-config=/usr/bin/gdal-config --global-option=-I/usr/include/gdal GDAL=={env:GDAL_VERSION:2.1.3}
+    pip install --global-option=build_ext --global-option=--gdal-config=/usr/bin/gdal-config --global-option=-I/usr/include/gdal GDAL=={env:GDAL_VERSION:2.3.1}
+    pip install rasterio
     pytest {posargs}
 whitelist_externals = env
 


### PR DESCRIPTION
When initiating a spatial reference using ImportProj4(raster.crs.to_string())
where crs.to_string is a rasterio Dataset method,
the spatial reference GetInvFlattening() returns a 0 and causes a division by zero
error.
The 3857 is a projection from a sphere(not a spheroid or ellipsoid), so the
Major and Minor should be equal.

local trials using a 3857 projection:
[zero_division_error.txt](https://github.com/ecometrica/gdal2mbtiles/files/2635250/zero_division_error.txt)
[division_by_zero_fixed.txt](https://github.com/ecometrica/gdal2mbtiles/files/2635251/division_by_zero_fixed.txt)

to verify the world extents refer to : 
https://epsg.io/3857