### PR TITLE
Make it more obvious that --min/max-resolution args are for zoom level

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -138,11 +138,11 @@ Command Line Interface
 
     Rendering arguments:
       --min-resolution MIN_RESOLUTION
-                            Minimum resolution to render and slice. Defaults to
-                            None (do not downsample)
+                            Minimum resolution/zoom level to render and slice.
+                            Defaults to None (do not downsample)
       --max-resolution MAX_RESOLUTION
-                            Maximum resolution to render and slice. Defaults to
-                            None (do not upsample)
+                            Maximum resolution/zoom level to render and slice.
+                            Defaults to None (do not upsample)
       --fill-borders        Fill image to whole world with empty tiles. Default.
       --no-fill-borders     Do not add borders to fill image.
       --zoom-offset N       Offset zoom level by N to fit unprojected images to

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,3 @@
-.. image:: https://api.shippable.com/projects/5a533bf2c944eb0600db12c9/badge?branch=master
-    :target: https://app.shippable.com/github/ecometrica/gdal2mbtiles
-
 ======================================================
  Convert GDAL-readable datasets into an MBTiles file.
 ======================================================

--- a/gdal2mbtiles/main.py
+++ b/gdal2mbtiles/main.py
@@ -170,10 +170,10 @@ def parse_args(args):
 
     group = parser.add_argument_group(title='Rendering arguments')
     group.add_argument('--min-resolution', type=int, default=None,
-                       help=('Minimum resolution to render and slice. '
+                       help=('Minimum resolution/zoom level to render and slice. '
                              'Defaults to None (do not downsample)'))
     group.add_argument('--max-resolution', type=int, default=None,
-                       help=('Maximum resolution to render and slice. '
+                       help=('Maximum resolution/zoom level to render and slice. '
                              'Defaults to None (do not upsample)'))
     group.add_argument('--fill-borders',
                        action='store_const', const=True, default=True,


### PR DESCRIPTION
It took me a while to figure that out, I assumed it was some sort of image resolution thing, not the actual zoom level.  These minor changes ensure other people won't have the same confusion.

I also removed the broken link/image at the top of the readme file.