### PR TITLE
Pin pyvips to 2.1.8 as 2.1.11 is causing errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 
-
 from setuptools import setup
 
 import gdal2mbtiles
@@ -17,7 +16,10 @@ multiprocessing
 setup(
     name='gdal2mbtiles',
     version=gdal2mbtiles.__version__,
-    description='Converts a GDAL-readable dataset into an MBTiles file. This is used to generate web maps.',
+    description=(
+        'Converts a GDAL-readable dataset into an MBTiles file.'
+        'This is used to generate web maps.'
+    ),
     long_description=open('README.rst').read(),
     license='Apache Software License, version 2.0',
 
@@ -27,7 +29,9 @@ setup(
 
     packages=['gdal2mbtiles'],
     include_package_data=True,
-    install_requires=['future', 'numexpr', 'numpy', 'pyvips', 'webcolors'],
+    install_requires=[
+        'future', 'numexpr', 'numpy', 'pyvips<=2.1.8', 'webcolors'
+    ],
     # You also need certain dependencies that aren't in PyPi:
     # gdal-bin, libgdal-dev, libvips, libvips-dev, libtiff5, optipng, pngquant
 

--- a/tests/test_spatial_reference.py
+++ b/tests/test_spatial_reference.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
-import rasterio
 import pytest
 
 from numpy import array
@@ -12,18 +10,14 @@ from gdal2mbtiles.constants import (EPSG_WEB_MERCATOR,
 from gdal2mbtiles.gdal import SpatialReference
 
 
-epsg_3857_raster_path = 'tests/web_mercator_3857.tif'
-
-
 @pytest.fixture
 def epsg_3857_from_proj4():
     """
     Return a gdal spatial reference object with
     3857 crs using the ImportFromProj4 method.
     """
-    ds_3857 = rasterio.open(epsg_3857_raster_path)
     spatial_ref = SpatialReference()
-    spatial_ref.ImportFromProj4(ds_3857.crs.to_string())
+    spatial_ref.ImportFromProj4('+init=epsg:3857')
     return spatial_ref
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ install_command=
 
 deps =
     future
-    pyvips
+    pyvips<=2.1.8
     pytest
     pytest-pythonpath
     numexpr

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@ envlist = py{27,35,36}
 [testenv]
 commands=
     pip install --global-option=build_ext --global-option=--gdal-config=/usr/bin/gdal-config --global-option=-I/usr/include/gdal GDAL=={env:GDAL_VERSION:2.1.3}
-    pip install rasterio
     pytest {posargs}
 whitelist_externals = env
 


### PR DESCRIPTION
This is a quick fix. gdal2mbtiles should be updated to support the latest pyvips.