### PR TITLE
float overflow bug

### DIFF
--- a/gdal2mbtiles/gdal.py
+++ b/gdal2mbtiles/gdal.py
@@ -887,8 +887,8 @@ class SpatialReference(osr.SpatialReference):
 
     def GetTileDimensions(self, resolution):
         # Assume square tiles.
-        width = self.GetMajorCircumference() / 2 ** resolution
-        height = self.GetMinorCircumference() / 2 ** resolution
+        width = int(self.GetMajorCircumference()) / 2 ** resolution
+        height = int(self.GetMinorCircumference()) / 2 ** resolution
         result = XY(width, height)
         if self.IsProjected() == 0:
             # Resolution 0 only covers a longitudinal hemisphere


### PR DESCRIPTION
When self.GetMajorCircumference() it usually returns a float 360.0 that can not be converted to int when ** resolution is done and returns a float point overflow error